### PR TITLE
[fix]: Pages snapshots inconsistent with different timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 * [ ] [feature]: 重构项目概览页面 <https://github.com/actiontech/sqle-ui/pull/292>
 * [ ] [chore]: 界面优化长期任务【2.2307.0】 <https://github.com/actiontech/sqle/issues/1658>
 * [ ] [feature]: 新增自定义规则页面 <https://github.com/actiontech/sqle-ui/pull/294>
+* [ ] [fix]: 在不同时间段执行 Order/Detail/index.test.tsx 和  AuditResultCollection.test.tsx 时, 生成的快照文件不一致. 原因: 这两个页面中有些按钮的状态需要通过当前时间和工单概览接口返回的数据源运维时间做判断, 由于在 test case 中未 mock 当前时间, 导致不同时间段的按钮状态不一致.

--- a/src/page/Order/AuditResult/__test__/AuditResultCollection.test.tsx
+++ b/src/page/Order/AuditResult/__test__/AuditResultCollection.test.tsx
@@ -76,6 +76,8 @@ const workflowId = '22';
 describe('test AuditResultCollection', () => {
   const mockSetAuditResultActiveKey = jest.fn();
   const mockRefreshOrder = jest.fn();
+  let nowSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockUseStyle();
     mockGetAllRules();
@@ -87,11 +89,17 @@ describe('test AuditResultCollection', () => {
         user: { username: 'admin' },
       })
     );
+    nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() =>
+        new Date('2023-07-11T09:19:54+08:00').getTime()
+      );
   });
 
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllTimers();
+    nowSpy.mockRestore();
   });
 
   const mockSuccessMessage = () => {

--- a/src/page/Order/Detail/__snapshots__/index.test.tsx.snap
+++ b/src/page/Order/Detail/__snapshots__/index.test.tsx.snap
@@ -2043,32 +2043,8 @@ exports[`Order/Detail should render on process order info by request 2`] = `
   <div
     class="ant-spin-nested-loading"
   >
-    <div>
-      <div
-        aria-busy="true"
-        aria-live="polite"
-        class="ant-spin ant-spin-spinning"
-      >
-        <span
-          class="ant-spin-dot ant-spin-dot-spin"
-        >
-          <i
-            class="ant-spin-dot-item"
-          />
-          <i
-            class="ant-spin-dot-item"
-          />
-          <i
-            class="ant-spin-dot-item"
-          />
-          <i
-            class="ant-spin-dot-item"
-          />
-        </span>
-      </div>
-    </div>
     <div
-      class="ant-spin-container ant-spin-blur"
+      class="ant-spin-container"
     >
       <div
         class="ant-page-header"

--- a/src/page/Order/Detail/__testData__/index.tsx
+++ b/src/page/Order/Detail/__testData__/index.tsx
@@ -610,7 +610,7 @@ export const workflowTasks: IGetWorkflowTasksItemV2[] = [
     instance_maintenance_times: [
       {
         maintenance_start_time: { hour: 0, minute: 0 },
-        maintenance_stop_time: { hour: 20, minute: 0 },
+        maintenance_stop_time: { hour: 10, minute: 0 },
       },
     ],
   },

--- a/src/page/Order/Detail/index.test.tsx
+++ b/src/page/Order/Detail/index.test.tsx
@@ -51,6 +51,7 @@ describe('Order/Detail', () => {
 
   let getInstanceSummarySpy: jest.SpyInstance;
   const error = console.error;
+  let nowSpy: jest.SpyInstance;
 
   beforeEach(() => {
     console.error = jest.fn((message: any) => {
@@ -78,6 +79,12 @@ describe('Order/Detail', () => {
     mockGetAllRules();
     getInstanceSummarySpy = mockGetSummaryOfInstanceTasks();
     jest.useFakeTimers();
+
+    nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() =>
+        new Date('2023-07-11T09:19:54+08:00').getTime()
+      );
   });
 
   afterEach(() => {
@@ -85,6 +92,7 @@ describe('Order/Detail', () => {
     jest.clearAllTimers();
     jest.clearAllMocks();
     console.error = error;
+    nowSpy.mockRestore();
   });
 
   const mockCancelWorkflow = () => {


### PR DESCRIPTION
[Order/Detail/__snapshots__/index.test.tsx.snap](https://github.com/actiontech/sqle-ui/compare/fix/test-snapshot-error?expand=1#diff-1514e3a0c3783db6fa11863148a502b452c9c90938acb92e881cd5c6c0f9b4cb) 出现快照更改的原因: mock 当前时间后 Spin 组件的快照会产生变更